### PR TITLE
Fixed the Version Checking

### DIFF
--- a/D810.py
+++ b/D810.py
@@ -54,11 +54,11 @@ class D810Plugin(idaapi.plugin_t):
             return idaapi.PLUGIN_SKIP
         
         ver = float(ida_kernwin.get_kernel_version())
-        if ver < 7.5
+        if ver < 7.5:
             print("Version mismatch; D-810 needs IDA version >= 7.5. Skipping")
+            return idaapi.PLUGIN_SKIP
         if ver >= 8:
             print(f"Notice: D-810 was built for IDA version 7.5. You are running v{ver}")
-            return idaapi.PLUGIN_SKIP
         print("D-810 initialized (version {0})".format(D810_VERSION))
         return idaapi.PLUGIN_OK
 

--- a/D810.py
+++ b/D810.py
@@ -52,7 +52,7 @@ class D810Plugin(idaapi.plugin_t):
         if not ida_hexrays.init_hexrays_plugin():
             print("D-810 need Hex-Rays decompiler. Skipping")
             return idaapi.PLUGIN_SKIP
-        
+
         ver = float(ida_kernwin.get_kernel_version())
         if ver < 7.5:
             print("Version mismatch; D-810 needs IDA version >= 7.5. Skipping")

--- a/D810.py
+++ b/D810.py
@@ -52,10 +52,12 @@ class D810Plugin(idaapi.plugin_t):
         if not ida_hexrays.init_hexrays_plugin():
             print("D-810 need Hex-Rays decompiler. Skipping")
             return idaapi.PLUGIN_SKIP
-
-        kv = ida_kernwin.get_kernel_version().split(".")
-        if (int(kv[0]) < 7) or (int(kv[1]) < 5):
-            print("D-810 need IDA version >= 7.5. Skipping")
+        
+        ver = float(ida_kernwin.get_kernel_version())
+        if ver < 7.5
+            print("Version mismatch; D-810 needs IDA version >= 7.5. Skipping")
+        if ver >= 8:
+            print(f"Notice: D-810 was built for IDA version 7.5. You are running v{ver}")
             return idaapi.PLUGIN_SKIP
         print("D-810 initialized (version {0})".format(D810_VERSION))
         return idaapi.PLUGIN_OK


### PR DESCRIPTION
Previously it would refuse to load on IDA 8.0 and above, fixed that. Additionally, it will print a message warning that the plugin was built for IDA 7.5.